### PR TITLE
Generate a unique branch tag in accordance with RFC3261

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 Change log
 
+v1.4
+  Generate a unique branch tag in accordance with RFC3261. This allows
+  PJSIP to repond to the correct port if there are multiple checks
+  within a short space of time
+  (Craig Gowing, credativ Ltd)
+
 v1.3
   Added SIP Re-tranmission
   (Ryanny Lin)

--- a/check_sip
+++ b/check_sip
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 #
 # check_sip plugin for nagios
-# $Revision: 1.3 $
+# $Revision: 1.4 $
 #
 # Nagios plugin to check SIP servers
 #
@@ -10,6 +10,8 @@
 # Michael Hirschbichler, Institute of Broadband Communications, 
 #  Vienna University of Technology
 # Ryanny Lin
+# Craig Gowing, credativ Ltd
+# http://www.credativ.co.uk/
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -36,7 +38,7 @@ use Net::Domain qw (hostname hostfqdn hostdomain);
 use Switch;
 
 $PROGNAME = "check_sip";
-my $VERSION  = "1.3.0";
+my $VERSION  = "1.4.0";
 
 $ENV{'BASH_ENV'}=''; 
 $ENV{'ENV'}='';
@@ -199,8 +201,9 @@ sub buildReq
   my $req;
   my $tag = genTag();
   my $idtag = genTag();
+  my $branch = genBranch();
   $req.= "OPTIONS $dsturi SIP/2.0\r\n";
-  $req.= "Via: SIP/2.0/UDP $localhost:$localport;branch=z9hG4bKhjhs8ass877\r\n";
+  $req.= "Via: SIP/2.0/UDP $localhost:$localport;branch=$branch\r\n";
   $req.= "Max-Forwards: 70\r\n";
   $req.= "To: $dsturi\r\n";
   $req.= "From: $fromuri;tag=$tag\r\n";
@@ -224,6 +227,20 @@ sub genTag
     $tag .= $chars[rand(scalar @chars)];
   }
   return $tag;
+}
+
+sub genBranch
+{
+  my $branch = "z9hG4bK";
+  my @chars = ('a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p',
+  'q','r','s','t','u','v','w','x','y','z','0','1','2','3','4','5','6','7','8',
+  '9');
+
+  for (my $i = 0; $i < 11; $i++)
+  {
+    $branch .= $chars[rand(scalar @chars)];
+  }
+  return $branch;
 }
 
 sub printHelp


### PR DESCRIPTION
This should fix a problem when checking Asterisk using PJSIP where Asterisk may respond to the wrong port when there are multiple requests. Eg.

check_sip (59123) -> asterisk (5060) : OPTIONS
asterisk (5060) -> check_sip (59123) : OK
check_sip (55321) -> asterisk (5060) : OPTIONS
asterisk (5060) -> check_sip (**59123**) : OK
asterisk host -> check_sip : ICMP Unreachable

The fix will cause a unique branch tag to be generated in the OPTIONS message which will cause PJSIP to treat it as a new transaction and respond to correctly to the source address, rather than what it thinks the source address is for the entire transaction.

To reproduce the issue:
- Have an asterisk instance running PJSIP and the checksip user configured
- Run the check more than once within a a minute
- Everything after the first request will either timeout or get a host unreachable response (depending on firewall settings)
